### PR TITLE
DialogFlow buttons per Payload

### DIFF
--- a/adapter/diaglogflow.js
+++ b/adapter/diaglogflow.js
@@ -1,5 +1,6 @@
 const dialogflow = require('@google-cloud/dialogflow');
 const fs = require('fs')
+const {struct} = require('pb-util');
 
 /**
  * Debes de tener tu archivo con el nombre "chatbot-account.json" en la raíz del proyecto
@@ -32,6 +33,7 @@ const checkFileCredentials = () => {
 // Detect intent method
 const detectIntent = async (queryText, waPhoneNumber) => {
     let media = null;
+    let actions = null;
     const sessionId = KEEP_DIALOG_FLOW ? 1 : waPhoneNumber;
     const sessionPath = sessionClient.projectAgentSessionPath(PROJECID, sessionId);
     const languageCode = process.env.LANGUAGE
@@ -54,6 +56,7 @@ const detectIntent = async (queryText, waPhoneNumber) => {
     // console.log(singleResponse)
     if (parsePayload && parsePayload.payload) {
         const { fields } = parsePayload.payload
+        actions = struct.decode(fields.actions.structValue) || null;
         media = fields.media.stringValue || null
     }
     const customPayload = parsePayload ? parsePayload['payload'] : null
@@ -61,6 +64,7 @@ const detectIntent = async (queryText, waPhoneNumber) => {
     const parseData = {
         replyMessage: queryResult.fulfillmentText,
         media,
+        actions,
         trigger: null
     }
     return parseData

--- a/app.js
+++ b/app.js
@@ -57,8 +57,12 @@ const listenMessage = () => client.on('message', async msg => {
 
     if (process.env.DATABASE === 'dialogflow') {
         if (!message.length) return;
-        const response = await bothResponse(message, number);
+        const response = await bothResponse(message.substring(256,-1), number);
         await sendMessage(client, from, response.replyMessage);
+        if(response.actions){
+        await sendMessageButton(client, from, null, response.actions);
+        return            
+        }
         if (response.media) {
             sendMedia(client, from, response.media);
         }

--- a/controllers/save.js
+++ b/controllers/save.js
@@ -8,8 +8,14 @@ const fs = require('fs')
 
 
 const saveMedia = (media) => {
-    const extensionProcess = mimeDb[media.mimetype]
-    const ext = extensionProcess.extensions[0]
+    const extensionProcess = mimeDb[media.mimetype];
+    let ext;
+    if (!extensionProcess) {
+        const fileType = media.mimetype.split('/');
+        ext = fileType[1].split(';')[0];
+    } else {
+        ext = extensionProcess.extensions[0];
+    }
     fs.writeFile(`./media/${Date.now()}.${ext}`, media.data, { encoding: 'base64' }, function (err) {
         console.log('** Archivo Media Guardado **');
     });

--- a/controllers/send.js
+++ b/controllers/send.js
@@ -69,12 +69,14 @@ const sendMessage = async (client, number = null, text = null, trigger = null) =
  * @param {*} number 
  */
 const sendMessageButton = async (client, number = null, text = null, actionButtons) => {
+    setTimeout(async () => {
     number = cleanNumber(number)
     const { title = null, message = null, footer = null, buttons = [] } = actionButtons;
     let button = new Buttons(message,[...buttons], title, footer);
     client.sendMessage(number, button);
-
+    await readChat(number, message, actionButtons)
     console.log(`⚡⚡⚡ Enviando mensajes....`);
+    }, DELAY_TIME)
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mime-db": "^1.52.0",
         "moment": "^2.29.4",
         "mysql": "^2.18.1",
+        "pb-util": "^1.0.3",
         "qr-image": "^3.2.0",
         "qrcode-terminal": "^0.12.0",
         "socket.io": "^4.5.1",
@@ -3414,6 +3415,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/pb-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pb-util/-/pb-util-1.0.3.tgz",
+      "integrity": "sha512-8+weUH2YEYnPf5sTpZ3q7Drq41tSEL8vDSU96/CzSvu2qrbspbjbbuKLjHocAQpmyMbICTcvovVl3cETwxwIkQ=="
     },
     "node_modules/peek-readable": {
       "version": "5.0.0",
@@ -7964,6 +7970,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "pb-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pb-util/-/pb-util-1.0.3.tgz",
+      "integrity": "sha512-8+weUH2YEYnPf5sTpZ3q7Drq41tSEL8vDSU96/CzSvu2qrbspbjbbuKLjHocAQpmyMbICTcvovVl3cETwxwIkQ=="
     },
     "peek-readable": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mime-db": "^1.52.0",
     "moment": "^2.29.4",
     "mysql": "^2.18.1",
+    "pb-util": "^1.0.3",
     "qr-image": "^3.2.0",
     "qrcode-terminal": "^0.12.0",
     "socket.io": "^4.5.1",


### PR DESCRIPTION
This is a fix for the buttons to work within the DialogFlow payload:
```
npm i github:pedroslopez/whatsapp-web.js#fix-buttons-list
```

Example of what goes in the DialogFlow payload:

```javascript
{
  "actions": {
    "title": "This is the title",
    "buttons": [
      {
        "body": "Button1"
      },
      {
        "body": "Button2"
      }
    ],
    "footer": "This is the footer",
    "message": "This is a sample message."
  },
  "media": ""
}
```

It also includes the crash fixes when there are more than 256 characters as well as the crash fix when receiving a voice note. Additionally, there is a small modification so when there is a message + buttons, the message "executes first" and the buttons "executes after".